### PR TITLE
Public and non-public fields and properties, remove spaces in field names

### DIFF
--- a/CsvUtil.cs
+++ b/CsvUtil.cs
@@ -100,7 +100,7 @@ namespace Sinbad {
 
                 string[] vals = EnumerateCsvLine(line).ToArray();
                 if (vals.Length >= 2) {
-                    SetField(vals[0].Trim(), vals[1], fi, pi, nonValueObject);
+                    SetField(RemoveSpaces(vals[0].Trim()), vals[1], fi, pi, nonValueObject);
                 } else {
                     Debug.LogWarning(string.Format("CsvUtil: ignoring line '{0}': not enough fields", line));
                 }
@@ -218,8 +218,10 @@ namespace Sinbad {
             int n = 0;
             foreach(string field in EnumerateCsvLine(header)) {
                 var trimmed = field.Trim();
-                if (!trimmed.StartsWith("#"))
+                if (!trimmed.StartsWith("#")) {
+                    trimmed = RemoveSpaces(trimmed);
                     headers[trimmed] = n;
+                }
                 ++n;
             }
             return headers;
@@ -281,5 +283,8 @@ namespace Sinbad {
             }
         }
 
+        private static string RemoveSpaces(string strValue) {
+            return Regex.Replace(strValue, @"\s", string.Empty);
+        }
     }
 }

--- a/Editor/TestCsvUtil.cs
+++ b/Editor/TestCsvUtil.cs
@@ -43,7 +43,7 @@ namespace Sinbad {
 
 			using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(csvData))) {
 				using (var sr = new StreamReader(ms)) {
-					CsvUtil.LoadObject(sr, t);
+					CsvUtil.LoadObject(sr, ref t);
 				}
 			}
 
@@ -66,7 +66,7 @@ namespace Sinbad {
 
 			using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(csvData))) {
 				using (var sr = new StreamReader(ms)) {
-					CsvUtil.LoadObject(sr, t);
+					CsvUtil.LoadObject(sr, ref t);
 				}
 			}
 
@@ -90,7 +90,7 @@ namespace Sinbad {
 
 			using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(csvData))) {
 				using (var sr = new StreamReader(ms)) {
-					CsvUtil.LoadObject(sr, t);
+					CsvUtil.LoadObject(sr, ref t);
 				}
 			}
 

--- a/Editor/TestCsvUtil.cs
+++ b/Editor/TestCsvUtil.cs
@@ -28,8 +28,61 @@ namespace Sinbad {
 			}
 		}
 
+        public class TestPropertiesObject {
+			public string StringProperty { get; private set; }
+			public int IntProperty { get; private set; }
+            public float FloatProperty { get; private set; }
+            public enum Colour {
+                Red = 1,
+                Green = 2,
+                Blue = 3,
+                Purple = 15
+            }
+            public Colour EnumProperty { get; private set; }
 
-		[Test]
+            public TestPropertiesObject() {}
+			public TestPropertiesObject(string s, int i, float f, Colour c) {
+				StringProperty = s;
+				IntProperty = i;
+				FloatProperty = f;
+                EnumProperty = c;
+            }
+		}
+
+        public class TestPropertiesAndFieldsObject {
+            public string StringMember { get; protected set; }
+            private string stringMember;
+            public string GetStringField() { return stringMember; }
+
+            public int IntMember { get; set; }
+            protected int intMember;
+            public int GetIntField() { return intMember; }
+
+            public float FloatMember { get; private set; }
+            public float floatMember;
+            public float GetFloatField() { return floatMember; }
+
+            public enum Colour {
+                Red = 1,
+                Green = 2,
+                Blue = 3,
+                Purple = 15
+            }
+            public Colour EnumMember { get; private set; }
+            private Colour enumMember;
+            public Colour GetEnumField() { return enumMember; }
+
+            public TestPropertiesAndFieldsObject() { }
+            public TestPropertiesAndFieldsObject(string s, int i, float f, Colour c) {
+                StringMember = stringMember = s;
+                IntMember = intMember = i;
+                FloatMember = floatMember = f;
+                EnumMember = enumMember = c;
+            }
+        }
+
+
+        [Test]
 		public void TestLoadSingle() {
 			// It's ok to have newline with padding at start, should trim field names (not values)
 			// Include spaces in string field value to prove all content preserved
@@ -136,7 +189,57 @@ Zaphod Beeblebrox,3.1,""Amazingly amazing"",000359,Green";
 
 		}
 
-		[Test]
+        [Test]
+        public void TestLoadProperties()  {
+            // It's ok to have newline with padding at start, should trim field names (not values)
+            // Include spaces in string field value to prove all content preserved
+            string csvData = @"StringProperty, Hello World  ,This is an ignored description,also ignored
+			EnumProperty,Blue,Something Something
+			IntProperty,1234,Comment here
+			FloatProperty,1.5,More commenting";
+
+            TestPropertiesObject t = new TestPropertiesObject();
+
+            using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(csvData))) {
+                using (var sr = new StreamReader(ms)) {
+                    CsvUtil.LoadObject(sr, ref t);
+                }
+            }
+
+            Assert.AreEqual(" Hello World  ", t.StringProperty);
+            Assert.AreEqual(1234, t.IntProperty);
+            Assert.That(t.FloatProperty, Is.InRange(1.4999f, 1.5001f)); // float imprecision
+            Assert.AreEqual(TestPropertiesObject.Colour.Blue, t.EnumProperty);
+        }
+
+        [Test]
+        public void TestLoadPropertiesAndFieldsSameName() {
+            // It's ok to have newline with padding at start, should trim field names (not values)
+            // Include spaces in string field value to prove all content preserved
+            string csvData = @"StringMember, Hello World  ,This is an ignored description,also ignored
+			EnumMember,Blue,Something Something
+			IntMember,1234,Comment here
+			FloatMember,1.5,More commenting";
+
+            TestPropertiesAndFieldsObject t = new TestPropertiesAndFieldsObject();
+
+            using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(csvData))) {
+                using (var sr = new StreamReader(ms)) {
+                    CsvUtil.LoadObject(sr, ref t);
+                }
+            }
+
+            Assert.AreEqual(" Hello World  ", t.StringMember);
+            Assert.AreEqual(" Hello World  ", t.GetStringField());
+            Assert.AreEqual(1234, t.IntMember);
+            Assert.AreEqual(1234, t.GetIntField());
+            Assert.That(t.FloatMember, Is.InRange(1.4999f, 1.5001f)); // float imprecision
+            Assert.That(t.GetFloatField(), Is.InRange(1.4999f, 1.5001f)); // float imprecision
+            Assert.AreEqual(TestPropertiesAndFieldsObject.Colour.Blue, t.EnumMember);
+            Assert.AreEqual(TestPropertiesAndFieldsObject.Colour.Blue, t.GetEnumField());
+        }
+
+        [Test]
 		public void TestSaveSingle() {
 
 			var obj = new TestObject("Hello there", 123, 300.2f, TestObject.Colour.Blue);


### PR DESCRIPTION
Hey,

I've implemented support for public and non-public fields and properties and also for spaces in field names to improve readability for e.g. designers.

I guess the changelogs and unit tests should make everything very clear.

Use at own will :)